### PR TITLE
[stackexchange] Add new data source stackexchange to reports

### DIFF
--- a/report/metrics/stackexchange.py
+++ b/report/metrics/stackexchange.py
@@ -1,0 +1,94 @@
+## Copyright (C) 2017 Bitergia
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+##
+##
+## Authors:
+##   Alvaro del Castillo <acs@bitergia.com>
+##
+
+from .metrics import Metrics
+
+class Stackexchange():
+    name = "stackexchange"
+
+    @classmethod
+    def get_section_metrics(cls):
+        return {
+            "overview" : {
+                "activity_metrics": [QuestionsSent],
+                "author_metrics": [],
+                "bmi_metrics": [],
+                "time_to_close_metrics": [],
+                "projects_metrics": [Projects]
+            },
+            "com_channels": {
+                "activity_metrics": [QuestionsSent],
+                "author_metrics": [QuestionsSenders]
+            },
+            "project_activity": {
+                # TODO: QuestionsSenders is not activity but we need two metrics here
+                "metrics": [QuestionsSent, QuestionsSenders]
+            },
+            "project_community": {
+                "author_metrics": [],
+                "people_top_metrics": [],
+                "orgs_top_metrics": [],
+            },
+            "project_process": {
+                "bmi_metrics": [],
+                "time_to_close_metrics": [],
+                "time_to_close_title": "",
+                "time_to_close_review_metrics": [],
+                "time_to_close_review_title": "",
+                "patchsets_metrics": []
+            }
+        }
+
+
+class StackexchangeMetrics(Metrics):
+    ds = Stackexchange
+
+
+class QuestionsSent(StackexchangeMetrics):
+    """ Questions metric class for stackexchange analysis """
+
+    id = "questions_sent"
+    name = "Sent Questions"
+    desc = "Questions sent to stackexchange site"
+    FIELD_COUNT = "uuid"  # field used to count questions
+    FIELD_NAME = "title"  # field used to list qyestions
+    filters = {"is_stackexchange_question":"1"}
+
+
+class QuestionsSenders(StackexchangeMetrics):
+    """ Questions Senders class for stackexchange analysis """
+
+    id = "questions_senders"
+    name = "Questions Senders"
+    desc = "People sending questions"
+
+    FIELD_COUNT = 'author_uuid' # field used to count Authors
+    FIELD_NAME = 'author_name' # field used to count Authors
+    filters = {"is_stackexchange_question":"1"}
+
+
+class Projects(StackexchangeMetrics):
+    """ Projects in the stackexchange """
+
+    id = "projects"
+    name = "Projects"
+    desc = "Projects in stackexchange"
+    FIELD_NAME = 'project' # field used to list projects

--- a/report/report.py
+++ b/report/report.py
@@ -47,6 +47,7 @@ from .metrics import github_issues
 from .metrics import github_prs
 from .metrics import mls
 from .metrics import gerrit
+from .metrics import stackexchange
 
 from .metrics.metrics import Metrics
 
@@ -59,6 +60,7 @@ class Report():
     JIRA_INDEX = 'jira'
     EMAIL_INDEX = 'mbox_enrich'
     GERRIT_INDEX = 'gerrit'
+    STACHEXCHANGE_INDEX = 'stackoverflow'
     GLOBAL_PROJECT = 'general'
     TOP_MAX = 20
 
@@ -69,6 +71,8 @@ class Report():
         github_prs.GitHubPRs: GITHUB_PRS_INDEX,
         jira.Jira: JIRA_INDEX,
         mls.MLS: EMAIL_INDEX
+        mls.MLS: EMAIL_INDEX,
+        stackexchange.Stackexchange: STACHEXCHANGE_INDEX
     }
 
     ds2class = {
@@ -78,11 +82,14 @@ class Report():
         "github_prs": github_prs.GitHubPRs,
         "jira": jira.Jira,
         "mailinglist": mls.MLS
+        "mailinglist": mls.MLS,
+        "stackexchange": stackexchange.Stackexchange
     }
 
     supported_data_sources = ['git', 'github', 'gerrit', 'mls']
     supported_data_sources += ['github_issues', 'github_prs']
     supported_data_sources += ['jira']
+    supported_data_sources += ['stackexchange']
 
     def __init__(self, es_url, start, end, data_dir=None, filters=None,
                  interval="month", offset=None, data_sources=None,


### PR DESCRIPTION
This implementation includes only metrics for Questions. It will be extended also to Answers.