### PR TITLE
JIRA BMI and Time to Close Metrics fixes

### DIFF
--- a/report/metrics/github_issues.py
+++ b/report/metrics/github_issues.py
@@ -92,11 +92,6 @@ class DaysToCloseAverage(its.DaysToCloseAverage):
     filters = {"state": "closed", "pull_request": "false"}
 
 
-class Closers(its.Closers):
-    ds = GitHubIssues
-    filters = {"state": "closed", "pull_request": "false"}
-
-
 class BMI(its.BMI):
     ds = GitHubIssues
     filters = {"pull_request": "false"}

--- a/report/metrics/jira.py
+++ b/report/metrics/jira.py
@@ -89,26 +89,26 @@ class Closed(JiraMetrics):
     id = "closed"
     name = "Closed tickets"
     desc = "Number of closed tickets"
-    # filters = {"status":["Closed", "Resolved", "Done"]}
-    filters = {"*status": "Open"}
     FIELD_COUNT = "key"
     FIELD_NAME = "url"
+    filters = {"*status": "Open"}
 
 
 class DaysToCloseMedian(its.DaysToCloseMedian):
     ds = Jira
+    filters = {"*status": "Open"}
 
 
 class DaysToCloseAverage(its.DaysToCloseAverage):
     ds = Jira
-
-
-class Closers(its.Closers):
-    ds = Jira
+    filters = {"*status": "Open"}
 
 
 class BMI(its.BMI):
     ds = Jira
+    # To use JIRA implementation inside BMI general implementation
+    closed_class = Closed
+    opened_class = Opened
 
 
 class Projects(its.Projects):


### PR DESCRIPTION
This PR fixes:

In BMI implementation the Opened and Closed classes to be used
depends on the type of issue (github, jira ...). Now they can be
changed in the specific type implementation which is needed in JIRA.

Added also the correct filter for detecting closed issues in JIRA in
DaysToCloseMedian and DaysToCloseAverage.
